### PR TITLE
Add Dashboard Navigation Test

### DIFF
--- a/hydroshare/config.py
+++ b/hydroshare/config.py
@@ -1,4 +1,4 @@
-BASE_URL = 'https://www.hydroshare.org/'
+BASE_URL = 'https://dev-hs-5.cuahsi.org/'
 USERNAME = 'jim'
 PASSWORD = '62meister'
 

--- a/hydroshare/config.py
+++ b/hydroshare/config.py
@@ -1,4 +1,4 @@
-BASE_URL = 'https://dev-hs-5.cuahsi.org/'
+BASE_URL = 'https://beta.hydroshare.org/'
 USERNAME = 'jim'
 PASSWORD = '62meister'
 

--- a/hydroshare/hs_elements.py
+++ b/hydroshare/hs_elements.py
@@ -505,7 +505,7 @@ class MyResourcesPage:
 
 class DashboardPage:
     def __init__(self):
-        self.get_started_toggle = SiteElement(By.ID, 'change_me')
+        self.get_started_toggle = SiteElement(By.ID, 'id-getting-started-toggle')
 
 DashboardPage = DashboardPage()
 HomePage = HomePage()

--- a/hydroshare/hs_elements.py
+++ b/hydroshare/hs_elements.py
@@ -5,6 +5,7 @@ from cuahsi_base.site_element import SiteElement
 
 class HomePage:
     def __init__(self):
+        self.to_home = SiteElement(By.ID, 'dropdown-menu-home')
         self.to_my_resources = SiteElement(By.ID, 'dropdown-menu-my-resources')
         self.to_discover = SiteElement(By.ID, 'dropdown-menu-search')
         self.to_apps = SiteElement(
@@ -502,7 +503,11 @@ class MyResourcesPage:
             '#dropdown-resource-type ul li:nth-of-type({})'.format(index),
         )
 
+class DashboardPage:
+    def __init__(self):
+        self.get_started_toggle = SiteElement(By.ID, 'change_me')
 
+DashboardPage = DashboardPage()
 HomePage = HomePage()
 AppsPage = AppsPage()
 DiscoverPage = DiscoverPage()

--- a/hydroshare/hs_macros.py
+++ b/hydroshare/hs_macros.py
@@ -545,7 +545,7 @@ class Dashboard:
         DashboardPage.get_started_toggle.click(driver)
 
     def is_get_started_showing(self, driver):
-        return DashboardPage.get_started_toggle.get_text(driver) == "Hide get started"
+        return DashboardPage.get_started_toggle.get_text(driver) == "Hide Getting Started"
 
 Home = Home()
 Apps = Apps()

--- a/hydroshare/hs_macros.py
+++ b/hydroshare/hs_macros.py
@@ -7,13 +7,16 @@ from dateutil import parser
 
 from hs_elements import HomePage, AppsPage, DiscoverPage, ResourcePage, \
      HelpPage, AboutPage, APIPage, LoginPage, ProfilePage, GroupsPage, \
-     GroupPage, NewGroupModal, MyResourcesPage
+     GroupPage, NewGroupModal, MyResourcesPage, DashboardPage
 from timing import HSAPI_GUI_RESPONSE, PROFILE_SAVE, HELP_DOCS_TREE_ANIMATIONS, \
      RESOURCE_CREATION, HOME_PAGE_SLIDER_ANIMATION, LABEL_CREATION, \
      HSAPI_RESPONSE_CODE
 
 
 class Home:
+    def to_home(self, driver):
+        HomePage.to_home.click(driver)
+
     def to_my_resources(self, driver):
         HomePage.to_my_resources.click(driver)
 
@@ -537,6 +540,12 @@ class MyResources:
     def exists_cancel_btn(self, driver):
         return 'disabled' not in MyResourcesPage.cancel_resource.get_class(driver)
 
+class Dashboard:
+    def toggle_get_started(self, driver): 
+        DashboardPage.get_started_toggle.click(driver)
+
+    def is_get_started_showing(self, driver):
+        return DashboardPage.get_started_toggle.get_text(driver) == "Hide get started"
 
 Home = Home()
 Apps = Apps()
@@ -549,3 +558,4 @@ Profile = Profile()
 Groups = Groups()
 Group = Group()
 MyResources = MyResources()
+Dashboard = Dashboard()

--- a/hydroshare/hydroshare.py
+++ b/hydroshare/hydroshare.py
@@ -7,7 +7,7 @@ import re
 from urllib.request import urlretrieve, urlopen
 
 from hs_macros import Home, Apps, Discover, Resource, Help, API, About, Profile, \
-    Groups, Group, MyResources
+    Groups, Group, MyResources, Dashboard
 from hs_elements import AppsPage, MyResourcesPage, HomePage, DiscoverPage
 
 from cuahsi_base.cuahsi_base import BaseTest, parse_args_run_tests
@@ -713,6 +713,22 @@ class HydroshareTestSuite(BaseTest):
         Discover.show_all(self.driver)
         oracle()
 
+    def test_B_000034(self):
+        """ Basic navigation to dashboard """
+
+        def oracle():
+            """ Expect get started to be showing """
+            self.assertTrue(Dashboard.is_get_started_showing(self.driver))
+
+        Home.login(self.driver, USERNAME, PASSWORD)
+        Dashboard.toggle_get_started(self.driver)
+        Dashboard.toggle_get_started(self.driver)
+        Home.to_home(self.driver)
+        oracle()
+        
+
 
 if __name__ == '__main__':
     parse_args_run_tests(HydroshareTestSuite)
+
+   

--- a/hydroshare/hydroshare.py
+++ b/hydroshare/hydroshare.py
@@ -730,5 +730,3 @@ class HydroshareTestSuite(BaseTest):
 
 if __name__ == '__main__':
     parse_args_run_tests(HydroshareTestSuite)
-
-   


### PR DESCRIPTION
New Dashboard Navigtation Testing.
Dashboard is read only page. It doesn't have write operation on the system. The part that is important to test is the "Show get started" link. The PR reflects the test.

@ndebuhr The dev-hs-5 is still in the configuration.  I think i should remove it in the PR. What do you think?